### PR TITLE
install script should respect DESTDIR.

### DIFF
--- a/infinisqlmgr/cfg.py
+++ b/infinisqlmgr/cfg.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # Copyright (c) 2013 Mark Travis <mtravis15432+src@gmail.com>
 # All rights reserved. No warranty, explicit or implicit, provided.

--- a/infinisqlmgr/gencfgenum.py
+++ b/infinisqlmgr/gencfgenum.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # Copyright (c) 2013 Mark Travis <mtravis15432+src@gmail.com>
 # All rights reserved. No warranty, explicit or implicit, provided.

--- a/infinisqlmgr/infinisqlmgr.py
+++ b/infinisqlmgr/infinisqlmgr.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # Copyright (c) 2013 Mark Travis <mtravis15432+src@gmail.com>
 # All rights reserved. No warranty, explicit or implicit, provided.

--- a/infinisqlmgr/topology.py
+++ b/infinisqlmgr/topology.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # Copyright (c) 2013 Mark Travis <mtravis15432+src@gmail.com>
 # All rights reserved. No warranty, explicit or implicit, provided.


### PR DESCRIPTION
DESTDIR is used during package stage installation.

Signed-off-by: Anatol Pomozov anatol.pomozov@gmail.com
